### PR TITLE
Fix COUNT error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -206,7 +206,12 @@ exports.Adapter = function(settings) {
 			+ buildJoinString()
 			+ buildDataString(whereClause, ' AND ', 'WHERE');
 			
-			connection.query(combinedQueryString, function(err, res) { responseCallback(null, res[0]['count'])});
+			connection.query(combinedQueryString, function(err, res) { 
+				if (err)
+					responseCallback(err, null);
+			  else
+					responseCallback(null, res[0]['count']);
+			});
 			resetQuery(combinedQueryString);
 		}
 		


### PR DESCRIPTION
- any error from the SQL query would cause exception to be raised rather
  than calling back with the error and giving the caller the opportunity
  to handle it.
