### PR TITLE
Fixed multiple insert issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -281,10 +281,10 @@ exports.Adapter = function(settings) {
 	};
 	
 	this.insert = function(tableName, dataSet, responseCallback, verb, querySuffix) {
+		if (typeof verb === 'undefined') {
+			var verb = 'INSERT';
+		}
 		if (Object.prototype.toString.call(dataSet) !== '[object Array]') {
-			if (typeof verb === 'undefined') {
-				var verb = 'INSERT';
-			}
 			if (typeof querySuffix === 'undefined') {
 				var querySuffix = '';
 			}


### PR DESCRIPTION
When runing insert for multiple records, the verb must be specified,
otherwise the query fails, which is not documented.
This commit extracts the snippet of code setting the verb default
value from if statemen, thus the verb won't be undefined when performing
batch insert.
