### PR TITLE
Normalized Connection Settings

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,15 +31,22 @@
 exports.Adapter = function(settings) {
 	
 	var mysql = require('mysql');
-
-	if (!settings.server) {
+	
+	if(settings.server) {
+		settings.host = settings.server;
+	}
+	if(settings.username) {
+		settings.user = settings.username;
+	}
+	
+	if (!settings.host) {
 		throw new Error('Unable to start ActiveRecord - no server given.');
 	}
 	if (!settings.port) {
 		settings.port = 3306;
 	}
-	if (!settings.username) {
-		settings.username = '';
+	if (!settings.user) {
+		settings.user = '';
 	}
 	if (!settings.password) {
 		settings.password = '';
@@ -48,13 +55,7 @@ exports.Adapter = function(settings) {
 		throw new Error('Unable to start ActiveRecord - no database given.');
 	}
 	
-	var connection = new mysql.createConnection({
-		host: settings.server,
-		port: settings.port,
-		user: settings.username,
-		password: settings.password,
-		database: settings.database
-	});
+	var connection = new mysql.createConnection(settings);
 	
 	if (settings.charset) {
 		connection.query('SET NAMES ' + settings.charset);


### PR DESCRIPTION
First off, great plugin. Thanks for sharing!

The connection settings were different between `node-mysql-activerecord` and `node-mysql`. This was not only confusing but also limiting. If there were certain connection flags one needed to use that are available in `node-mysql` but not in your activerecord extension ( **timezone**, **socketPath**, **insecureAuth**, etc...), they wouldn't be able to use activerecord&mdash;which would be a major bummer.

Since the only settings you were using (at the moment) dealt with connection settings for the node-mysql module, I just removed the custom object you made to pass to it and simply passed the entire settings object. This will allow users to use any of the options available to them by `node-mysql`.

Furthermore, I made it so that the changes would be backwards compatible with earlier versions. In other words, using 'server' and 'username' settings will still work. Probably would be good to deprecate when you go to _0.9.x_ and remove entirely at _1.0.0_.

If you want to support custom settings for the activerecord module itself, it could be done pretty easily in various ways. 

For example:

```
var db = new Db.Adapter({
    connection: {
        server:   'localhost',
        username: 'my_user',
        password: 'my_password',
        database: 'my_database'
    },
    custom: 'settings',
    can: 'go here',
    easy: true
});
```

Then it would be as easy as changing index.js to:

```
var connection = new mysql.createConnection(settings.connection);
```

I really hope you can incorporate this change.
