### PR TITLE
avoid a following warning. (node) warning: possible EventEmitter memory leak detected.

### DIFF
--- a/index.js
+++ b/index.js
@@ -468,7 +468,9 @@ var Adapter = function(settings) {
 		});
 	}
 
-	handleDisconnect(connection);
+	if (!pool) {
+		handleDisconnect(connection);
+	}
 
 	var that = this;
 	


### PR DESCRIPTION
The connections that created by the Pool object should handled by the object.

```
(node) warning: possible EventEmitter memory leak detected. 11 listeners a
dded. Use emitter.setMaxListeners() to increase limit.
Trace
    at Connection.EventEmitter.addListener (events.js:160:15)
    at handleDisconnect (/home/webservice/ring-chat/node_modules/jails/nod
e_modules/mysql-activerecord/index.js:454:22)
    at new Adapter (/home/webservice/ring-chat/node_modules/jails/node_mod
ules/mysql-activerecord/index.js:471:2)
    at /home/webservice/ring-chat/node_modules/jails/node_modules/mysql-ac
tiverecord/index.js:521:18
    at Pool.getConnection (/home/webservice/ring-chat/node_modules/jails/n
ode_modules/mysql-activerecord/node_modules/mysql/lib/Pool.js:25:5)
    at getNewAdapter (/home/webservice/ring-chat/node_modules/jails/node_m
odules/mysql-activerecord/index.js:517:13)
    at /home/webservice/ring-chat/app/events/filters/check_user.js:9:10
    at try_callback (/home/webservice/ring-chat/node_modules/jails/node_mo
dules/socket.io/node_modules/redis/index.js:522:9)
    at RedisClient.return_reply (/home/webservice/ring-chat/node_modules/j
ails/node_modules/socket.io/node_modules/redis/index.js:592:13)
    at HiredisReplyParser.<anonymous> (/home/webservice/ring-chat/node_mod
ules/jails/node_modules/socket.io/node_modules/redis/index.js:265:14)
```
