### PR TITLE
Fixed Memory Leak Associated with Pools

### DIFF
--- a/index.js
+++ b/index.js
@@ -449,27 +449,29 @@ var Adapter = function(settings) {
 	};
 
 	var reconnectingTimeout = false;
-
-	function handleDisconnect(connectionInstance) {
-		connectionInstance.on('error', function(err) {
-			if (!err.fatal || reconnectingTimeout) {
-				return;
-			}
-
-			if (err.code !== 'PROTOCOL_CONNECTION_LOST' && err.code !== 'ECONNREFUSED') {
-				throw err;
-			}
-
-			var reconnectingTimeout = setTimeout(function() {
-				connection = mysql.createConnection(connectionInstance.config);
-				handleDisconnect(connection);
-				connection.connect();
-			}, 2000);
-		});
+	
+	if(settings && !settings.pool) {
+		function handleDisconnect(connectionInstance) {
+			connectionInstance.on('error', function(err) {
+				if (!err.fatal || reconnectingTimeout) {
+					return;
+				}
+	
+				if (err.code !== 'PROTOCOL_CONNECTION_LOST' && err.code !== 'ECONNREFUSED') {
+					throw err;
+				}
+	
+				var reconnectingTimeout = setTimeout(function() {
+					connection = mysql.createConnection(connectionInstance.config);
+					handleDisconnect(connection);
+					connection.connect();
+				}, 2000);
+			});
+		}
+	
+		handleDisconnect(connection);
 	}
-
-	handleDisconnect(connection);
-
+	
 	var that = this;
 	
 	return this;


### PR DESCRIPTION
The library should not use the handleDisconnect function when working with pools because it will cause the following error message to arise over time:

"warning: possible EventEmitter memory leak detected. 11 listeners added."

The pool now handles the opening and closing of connections, so we don't really need this for connection pools.
