### PR TITLE
Batch insert fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -363,7 +363,7 @@ var Adapter = function(settings) {
 					if (dataSet[i].hasOwnProperty(columns[key])) {
 						row.push(that.escape(dataSet[i][columns[key]]));
 					} else {
-						row.push('NULL');
+						row.push(null);
 					}
 				}
 


### PR DESCRIPTION
When you doing a batch insert and the objects in the array had different set of keys the batch insert would take the keys from the first object.
Now it take all unique keys from all the objects and fills the missing values a NULL.
